### PR TITLE
Fix typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       local:
       ebm-filrouge:
         aliases:
-          - tengui
+          - tenugui
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:tenugui.ebm.nymous.io"


### PR DESCRIPTION
May break deployment since it was a typo in the docker network alias